### PR TITLE
TST: temporary fix for testing workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         mongodb-version: [4.0, 4.2]
-        dtool-lookup-server-version: [0.15.0]
+        dtool-lookup-server-version: [0.15.0, 0.16.0, 0.17.0]
 
     steps:
     - name: Git checkout
@@ -32,6 +32,7 @@ jobs:
         pip install flake8 pytest
         pip install dtool-lookup-server==${{ matrix.dtool-lookup-server-version }}
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install Flask-JWT-Extended==3.25.0  # version 4.2.0 (and possibly earlier ones after 3.25.0) breaks plugin
         pip install .
         pip list
 


### PR DESCRIPTION
by fixing Flask-JWT-Extended version to 3.25.0. 

With version 4.2.0 (current), all tests fail with the following error:

```
__________________________________________________________________________ ERROR at setup of test_generate_many_dependency_views __________________________________________________________________________

request = <SubRequest 'tmp_app_with_dependent_data' for <Function test_generate_many_dependency_views>>

    @pytest.fixture
    def tmp_app_with_dependent_data(request):
        from dtool_lookup_server.config import Config
        from dtool_lookup_server import create_app, mongo, sql_db
        from dtool_lookup_server.utils import (
            register_users,
            register_base_uri,
            register_dataset,
            update_permissions,
        )
    
        tmp_mongo_db_name = random_string()
    
        config = {
            "FLASK_ENV": "development",
            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
            "MONGO_URI": "mongodb://localhost:27017/{}".format(tmp_mongo_db_name),
            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
            "JWT_ALGORITHM": "RS256",
            "JWT_PUBLIC_KEY": JWT_PUBLIC_KEY,
            "JWT_TOKEN_LOCATION": "headers",
            "JWT_HEADER_NAME": "Authorization",
            "JWT_HEADER_TYPE": "Bearer",
        }
    
>       app = create_app(config)

tests/__init__.py:247: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/dtool_lookup_server/__init__.py:74: in create_app
    app.register_blueprint(dataset_routes.bp)
../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/flask/app.py:98: in wrapper_func
    return f(self, *args, **kwargs)
../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/flask/app.py:1168: in register_blueprint
    blueprint.register(self, options, first_registration)
../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/flask/blueprints.py:256: in register
    deferred(state)
../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/flask/blueprints.py:294: in <lambda>
    self.record(lambda s: s.add_url_rule(rule, endpoint, view_func, **options))
../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/flask/blueprints.py:81: in add_url_rule
    self.app.add_url_rule(
../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/flask/app.py:98: in wrapper_func
    return f(self, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Flask 'dtool_lookup_server'>, rule = <Rule '/dataset/list' (GET, HEAD, OPTIONS) -> dataset.wrapper>, endpoint = 'dataset.wrapper'
view_func = <function jwt_required.<locals>.wrapper at 0x7fc389d0adc0>, provide_automatic_options = True, options = {'defaults': {}, 'endpoint': 'dataset.wrapper', 'subdomain': None}
methods = {'GET', 'OPTIONS'}, required_methods = {'OPTIONS'}, old_func = <function jwt_required.<locals>.wrapper at 0x7fc389d0ac10>

    @setupmethod
    def add_url_rule(
        self,
        rule,
        endpoint=None,
        view_func=None,
        provide_automatic_options=None,
        **options
    ):
        """Connects a URL rule.  Works exactly like the :meth:`route`
        decorator.  If a view_func is provided it will be registered with the
        endpoint.
    
        Basically this example::
    
            @app.route('/')
            def index():
                pass
    
        Is equivalent to the following::
    
            def index():
                pass
            app.add_url_rule('/', 'index', index)
    
        If the view_func is not provided you will need to connect the endpoint
        to a view function like so::
    
            app.view_functions['index'] = index
    
        Internally :meth:`route` invokes :meth:`add_url_rule` so if you want
        to customize the behavior via subclassing you only need to change
        this method.
    
        For more information refer to :ref:`url-route-registrations`.
    
        .. versionchanged:: 0.2
           `view_func` parameter added.
    
        .. versionchanged:: 0.6
           ``OPTIONS`` is added automatically as method.
    
        :param rule: the URL rule as string
        :param endpoint: the endpoint for the registered URL rule.  Flask
                         itself assumes the name of the view function as
                         endpoint
        :param view_func: the function to call when serving a request to the
                          provided endpoint
        :param provide_automatic_options: controls whether the ``OPTIONS``
            method should be added automatically. This can also be controlled
            by setting the ``view_func.provide_automatic_options = False``
            before adding the rule.
        :param options: the options to be forwarded to the underlying
                        :class:`~werkzeug.routing.Rule` object.  A change
                        to Werkzeug is handling of method options.  methods
                        is a list of methods this rule should be limited
                        to (``GET``, ``POST`` etc.).  By default a rule
                        just listens for ``GET`` (and implicitly ``HEAD``).
                        Starting with Flask 0.6, ``OPTIONS`` is implicitly
                        added and handled by the standard request handling.
        """
        if endpoint is None:
            endpoint = _endpoint_from_view_func(view_func)
        options["endpoint"] = endpoint
        methods = options.pop("methods", None)
    
        # if the methods are not given and the view_func object knows its
        # methods we can use that instead.  If neither exists, we go with
        # a tuple of only ``GET`` as default.
        if methods is None:
            methods = getattr(view_func, "methods", None) or ("GET",)
        if isinstance(methods, string_types):
            raise TypeError(
                "Allowed methods have to be iterables of strings, "
                'for example: @app.route(..., methods=["POST"])'
            )
        methods = set(item.upper() for item in methods)
    
        # Methods that should always be added
        required_methods = set(getattr(view_func, "required_methods", ()))
    
        # starting with Flask 0.8 the view_func object can disable and
        # force-enable the automatic options handling.
        if provide_automatic_options is None:
            provide_automatic_options = getattr(
                view_func, "provide_automatic_options", None
            )
    
        if provide_automatic_options is None:
            if "OPTIONS" not in methods:
                provide_automatic_options = True
                required_methods.add("OPTIONS")
            else:
                provide_automatic_options = False
    
        # Add the required methods now.
        methods |= required_methods
    
        rule = self.url_rule_class(rule, methods=methods, **options)
        rule.provide_automatic_options = provide_automatic_options
    
        self.url_map.add(rule)
        if view_func is not None:
            old_func = self.view_functions.get(endpoint)
            if old_func is not None and old_func != view_func:
>               raise AssertionError(
                    "View function mapping is overwriting an "
                    "existing endpoint function: %s" % endpoint
                )
E               AssertionError: View function mapping is overwriting an existing endpoint function: dataset.wrapper

../../../venv/jlh-imtek-python-3.8/lib/python3.8/site-packages/flask/app.py:1282: AssertionError
```